### PR TITLE
feat : auth_key 발급 및 OpenAPI data query

### DIFF
--- a/api/src/main/java/com/jhsfully/api/exception/ApiPermissionException.java
+++ b/api/src/main/java/com/jhsfully/api/exception/ApiPermissionException.java
@@ -1,0 +1,14 @@
+package com.jhsfully.api.exception;
+
+import com.jhsfully.domain.type.errortype.ApiPermissionErrorType;
+import lombok.Getter;
+
+@Getter
+public class ApiPermissionException extends CustomException{
+  private final ApiPermissionErrorType apiPermissionErrorType;
+
+  public ApiPermissionException(ApiPermissionErrorType apiPermissionErrorType){
+    super(apiPermissionErrorType.getMessage());
+    this.apiPermissionErrorType = apiPermissionErrorType;
+  }
+}

--- a/api/src/main/java/com/jhsfully/api/model/permission/AuthKeyResponse.java
+++ b/api/src/main/java/com/jhsfully/api/model/permission/AuthKeyResponse.java
@@ -1,0 +1,14 @@
+package com.jhsfully.api.model.permission;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class AuthKeyResponse {
+  private String authKey;
+}

--- a/api/src/main/java/com/jhsfully/api/model/query/QueryInput.java
+++ b/api/src/main/java/com/jhsfully/api/model/query/QueryInput.java
@@ -1,0 +1,19 @@
+package com.jhsfully.api.model.query;
+
+import java.util.Map;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class QueryInput {
+  private long apiId;
+  private String authKey;
+  private int pageSize;
+  private int pageIdx;
+  private Map<String, Object> queryParameter;
+}

--- a/api/src/main/java/com/jhsfully/api/model/query/QueryResponse.java
+++ b/api/src/main/java/com/jhsfully/api/model/query/QueryResponse.java
@@ -1,0 +1,22 @@
+package com.jhsfully.api.model.query;
+
+import java.util.List;
+import java.util.Map;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class QueryResponse {
+
+  private long totalCount;
+  private long dataCount;
+  List<Map> dataList;
+
+}

--- a/api/src/main/java/com/jhsfully/api/model/query/QueryResponse.java
+++ b/api/src/main/java/com/jhsfully/api/model/query/QueryResponse.java
@@ -17,6 +17,6 @@ public class QueryResponse {
 
   private long totalCount;
   private long dataCount;
-  List<Map> dataList;
+  private List<Map> dataList;
 
 }

--- a/api/src/main/java/com/jhsfully/api/restcontroller/ApiPermissionController.java
+++ b/api/src/main/java/com/jhsfully/api/restcontroller/ApiPermissionController.java
@@ -1,4 +1,45 @@
 package com.jhsfully.api.restcontroller;
+
+import com.jhsfully.api.service.ApiPermissionService;
+import com.jhsfully.api.util.MemberUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/permission")
+@RequiredArgsConstructor
 public class ApiPermissionController {
+
+  private final ApiPermissionService apiPermissionService;
+
+  @GetMapping("/{apiId}")
+  public ResponseEntity<?> getAuthKey(@PathVariable long apiId){
+    long memberId = MemberUtil.getMemberId();
+    return ResponseEntity.ok(
+        apiPermissionService.getAuthKey(memberId, apiId)
+    );
+  }
+
+  @PostMapping("/{apiId}")
+  public ResponseEntity<?> createAuthKey(@PathVariable long apiId){
+    long memberId = MemberUtil.getMemberId();
+    return ResponseEntity.ok(
+        apiPermissionService.createAuthKey(memberId, apiId)
+    );
+  }
+
+  @PatchMapping("/{apiId}")
+  public ResponseEntity<?> refreshAuthKey(@PathVariable long apiId){
+    long memberId = MemberUtil.getMemberId();
+    return ResponseEntity.ok(
+        apiPermissionService.refreshAuthKey(memberId, apiId)
+    );
+  }
 
 }

--- a/api/src/main/java/com/jhsfully/api/restcontroller/QueryController.java
+++ b/api/src/main/java/com/jhsfully/api/restcontroller/QueryController.java
@@ -1,0 +1,43 @@
+package com.jhsfully.api.restcontroller;
+
+import com.jhsfully.api.model.query.QueryInput;
+import com.jhsfully.api.model.query.QueryResponse;
+import com.jhsfully.api.service.QueryService;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/query")
+@RequiredArgsConstructor
+public class QueryController {
+
+  private final QueryService queryService;
+
+  @GetMapping("/{apiId}/{authKey}/{pageSize}/{pageIdx}")
+  public ResponseEntity<QueryResponse> getOpenAPIDataList(
+      @PathVariable long apiId,
+      @PathVariable String authKey,
+      @PathVariable int pageSize,
+      @PathVariable int pageIdx,
+      @RequestParam Map<String, Object> queryParameter
+  ){
+    QueryInput input = QueryInput.builder()
+        .apiId(apiId)
+        .authKey(authKey)
+        .pageSize(pageSize)
+        .pageIdx(pageIdx)
+        .queryParameter(queryParameter)
+        .build();
+
+    return ResponseEntity.ok(
+        queryService.getDataList(input)
+    );
+  }
+
+}

--- a/api/src/main/java/com/jhsfully/api/security/SecurityConfiguration.java
+++ b/api/src/main/java/com/jhsfully/api/security/SecurityConfiguration.java
@@ -56,7 +56,8 @@ public class SecurityConfiguration{
     return web -> {
       web.ignoring()
           .antMatchers(
-              "/**",  //이건 일단 테스트 용도로 추가함.
+
+              "/query/**",  //데이터 질의는 로그인 대신 auth_key로 대체함.
               "/auth/**",
               "/images/**",
               "/js/**",

--- a/api/src/main/java/com/jhsfully/api/service/ApiPermissionService.java
+++ b/api/src/main/java/com/jhsfully/api/service/ApiPermissionService.java
@@ -1,0 +1,11 @@
+package com.jhsfully.api.service;
+
+import com.jhsfully.api.model.permission.AuthKeyResponse;
+
+public interface ApiPermissionService {
+  AuthKeyResponse getAuthKey(long memberId, long apiId);
+
+  AuthKeyResponse createAuthKey(long memberId, long apiId);
+
+  AuthKeyResponse refreshAuthKey(long memberId, long apiId);
+}

--- a/api/src/main/java/com/jhsfully/api/service/QueryService.java
+++ b/api/src/main/java/com/jhsfully/api/service/QueryService.java
@@ -1,0 +1,8 @@
+package com.jhsfully.api.service;
+
+import com.jhsfully.api.model.query.QueryInput;
+import com.jhsfully.api.model.query.QueryResponse;
+
+public interface QueryService {
+  QueryResponse getDataList(QueryInput input);
+}

--- a/api/src/main/java/com/jhsfully/api/service/impl/ApiPermissionServiceImpl.java
+++ b/api/src/main/java/com/jhsfully/api/service/impl/ApiPermissionServiceImpl.java
@@ -1,0 +1,125 @@
+package com.jhsfully.api.service.impl;
+
+import static com.jhsfully.domain.type.errortype.ApiErrorType.API_NOT_FOUND;
+import static com.jhsfully.domain.type.errortype.ApiPermissionErrorType.API_KEY_ALREADY_ISSUED;
+import static com.jhsfully.domain.type.errortype.ApiPermissionErrorType.API_KEY_NOT_ISSUED;
+import static com.jhsfully.domain.type.errortype.ApiPermissionErrorType.USER_HAS_NOT_API;
+import static com.jhsfully.domain.type.errortype.AuthenticationErrorType.AUTHENTICATION_USER_NOT_FOUND;
+
+import com.jhsfully.api.exception.ApiException;
+import com.jhsfully.api.exception.ApiPermissionException;
+import com.jhsfully.api.exception.AuthenticationException;
+import com.jhsfully.api.model.permission.AuthKeyResponse;
+import com.jhsfully.api.service.ApiPermissionService;
+import com.jhsfully.domain.entity.ApiInfo;
+import com.jhsfully.domain.entity.ApiKey;
+import com.jhsfully.domain.entity.Member;
+import com.jhsfully.domain.repository.ApiInfoRepository;
+import com.jhsfully.domain.repository.ApiKeyRepository;
+import com.jhsfully.domain.repository.ApiUserPermissionRepository;
+import com.jhsfully.domain.repository.MemberRepository;
+import java.util.Objects;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ApiPermissionServiceImpl implements ApiPermissionService {
+
+  private final ApiInfoRepository apiInfoRepository;
+  private final ApiUserPermissionRepository apiUserPermissionRepository;
+  private final ApiKeyRepository apiKeyRepository;
+  private final MemberRepository memberRepository;
+
+
+  @Override
+  public AuthKeyResponse getAuthKey(long memberId, long apiId) {
+    validate(memberId, apiId);
+
+    Member member = memberRepository.findById(memberId)
+        .orElseThrow(() -> new AuthenticationException(AUTHENTICATION_USER_NOT_FOUND));
+    ApiInfo apiInfo = apiInfoRepository.findById(apiId)
+        .orElseThrow(() -> new ApiException(API_NOT_FOUND));
+
+    ApiKey apiKey = apiKeyRepository.findByApiInfoAndMember(apiInfo, member)
+        .orElseThrow(() -> new ApiPermissionException(API_KEY_NOT_ISSUED));
+    return new AuthKeyResponse(apiKey.getAuthKey());
+  }
+
+  @Override
+  public AuthKeyResponse createAuthKey(long memberId, long apiId) {
+    validate(memberId, apiId);
+
+    Member member = memberRepository.findById(memberId)
+        .orElseThrow(() -> new AuthenticationException(AUTHENTICATION_USER_NOT_FOUND));
+    ApiInfo apiInfo = apiInfoRepository.findById(apiId)
+        .orElseThrow(() -> new ApiException(API_NOT_FOUND));
+
+    if(apiKeyRepository.findByApiInfoAndMember(apiInfo, member).isPresent()){
+      throw new ApiPermissionException(API_KEY_ALREADY_ISSUED);
+    }
+
+    String apiKeyString = UUID.randomUUID().toString().replaceAll("-", "");
+
+    ApiKey apiKey = ApiKey.builder()
+        .apiInfo(apiInfo)
+        .member(member)
+        .authKey(apiKeyString)
+        .build();
+
+    apiKeyRepository.save(apiKey);
+
+    return new AuthKeyResponse(apiKeyString);
+  }
+
+  @Override
+  public AuthKeyResponse refreshAuthKey(long memberId, long apiId) {
+    validate(memberId, apiId);
+
+    Member member = memberRepository.findById(memberId)
+        .orElseThrow(() -> new AuthenticationException(AUTHENTICATION_USER_NOT_FOUND));
+    ApiInfo apiInfo = apiInfoRepository.findById(apiId)
+        .orElseThrow(() -> new ApiException(API_NOT_FOUND));
+
+    ApiKey apiKey = apiKeyRepository.findByApiInfoAndMember(apiInfo, member)
+        .orElseThrow(() -> new ApiPermissionException(API_KEY_NOT_ISSUED));
+
+    String apiKeyString = UUID.randomUUID().toString().replaceAll("-", "");
+
+    apiKey.setAuthKey(apiKeyString);
+
+    apiKeyRepository.save(apiKey);
+
+    return new AuthKeyResponse(apiKeyString);
+  }
+
+    /*
+      ###############################################################
+      ###############                           #####################
+      ###############          Validates        #####################
+      ###############                           #####################
+      ###############################################################
+   */
+
+  private void validate(long memberId, long apiId){
+    Member member = memberRepository.findById(memberId)
+        .orElseThrow(() -> new AuthenticationException(AUTHENTICATION_USER_NOT_FOUND));
+
+    ApiInfo apiInfo = apiInfoRepository.findById(apiId)
+        .orElseThrow(() -> new ApiException(API_NOT_FOUND));
+
+    //자신이 소유하고 있는 API라면, 바로 리턴.
+    if(Objects.equals(apiInfo.getMember().getId(), member.getId())){
+      return;
+    }
+
+    //허락된 API인지 확인해야함.
+    apiUserPermissionRepository.findByApiInfoAndMember(apiInfo, member)
+        .orElseThrow(() -> new ApiPermissionException(USER_HAS_NOT_API));
+  }
+
+
+}

--- a/api/src/main/java/com/jhsfully/api/service/impl/QueryServiceImpl.java
+++ b/api/src/main/java/com/jhsfully/api/service/impl/QueryServiceImpl.java
@@ -10,7 +10,6 @@ import com.jhsfully.api.model.query.QueryInput;
 import com.jhsfully.api.model.query.QueryResponse;
 import com.jhsfully.api.service.QueryService;
 import com.jhsfully.domain.entity.ApiInfo;
-import com.jhsfully.domain.entity.ApiKey;
 import com.jhsfully.domain.repository.ApiInfoRepository;
 import com.jhsfully.domain.repository.ApiKeyRepository;
 import com.jhsfully.domain.type.ApiQueryType;
@@ -71,7 +70,7 @@ public class QueryServiceImpl implements QueryService {
     ApiInfo apiInfo = apiInfoRepository.findById(input.getApiId())
         .orElseThrow(() -> new ApiException(API_NOT_FOUND));
 
-    ApiKey apiKey = apiKeyRepository.findByApiInfoAndAuthKey(apiInfo, input.getAuthKey())
+    apiKeyRepository.findByApiInfoAndAuthKey(apiInfo, input.getAuthKey())
         .orElseThrow(() -> new ApiPermissionException(API_KEY_NOT_ISSUED));
 
     //쿼리 파라미터에 대한 검증

--- a/api/src/main/java/com/jhsfully/api/service/impl/QueryServiceImpl.java
+++ b/api/src/main/java/com/jhsfully/api/service/impl/QueryServiceImpl.java
@@ -18,6 +18,7 @@ import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -47,7 +48,10 @@ public class QueryServiceImpl implements QueryService {
 
     query.with(pageable);
 
-    List<Map> results = mongoTemplate.find(query, Map.class, apiInfo.getDataCollectionName());
+    List<Map> results = mongoTemplate.find(query, Map.class, apiInfo.getDataCollectionName())
+        .stream()
+        .peek(x -> x.put("_id", x.get("_id").toString()))
+        .collect(Collectors.toList());
 
     return QueryResponse.builder()
         .totalCount(totalCount)

--- a/api/src/main/java/com/jhsfully/api/service/impl/QueryServiceImpl.java
+++ b/api/src/main/java/com/jhsfully/api/service/impl/QueryServiceImpl.java
@@ -1,0 +1,188 @@
+package com.jhsfully.api.service.impl;
+
+import static com.jhsfully.domain.type.errortype.ApiErrorType.API_NOT_FOUND;
+import static com.jhsfully.domain.type.errortype.ApiErrorType.QUERY_PARAMETER_CANNOT_MATCH;
+import static com.jhsfully.domain.type.errortype.ApiPermissionErrorType.API_KEY_NOT_ISSUED;
+
+import com.jhsfully.api.exception.ApiException;
+import com.jhsfully.api.exception.ApiPermissionException;
+import com.jhsfully.api.model.query.QueryInput;
+import com.jhsfully.api.model.query.QueryResponse;
+import com.jhsfully.api.service.QueryService;
+import com.jhsfully.domain.entity.ApiInfo;
+import com.jhsfully.domain.entity.ApiKey;
+import com.jhsfully.domain.repository.ApiInfoRepository;
+import com.jhsfully.domain.repository.ApiKeyRepository;
+import com.jhsfully.domain.type.ApiQueryType;
+import com.jhsfully.domain.type.ApiStructureType;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.core.query.TextCriteria;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class QueryServiceImpl implements QueryService {
+
+  private final ApiInfoRepository apiInfoRepository;
+  private final ApiKeyRepository apiKeyRepository;
+  private final MongoTemplate mongoTemplate;
+
+  public QueryResponse getDataList(QueryInput input){
+    validate(input);
+
+    Pageable pageable = PageRequest.of(input.getPageIdx(), input.getPageSize());
+    Query query = getQuery(input);
+    ApiInfo apiInfo = apiInfoRepository.findById(input.getApiId())
+        .orElseThrow(() -> new ApiException(API_NOT_FOUND));
+
+    long totalCount = mongoTemplate.count(query, apiInfo.getDataCollectionName());
+
+    query.with(pageable);
+
+    List<Map> results = mongoTemplate.find(query, Map.class, apiInfo.getDataCollectionName());
+
+    return QueryResponse.builder()
+        .totalCount(totalCount)
+        .dataCount(results.size())
+        .dataList(results)
+        .build();
+  }
+
+
+    /*
+      ###############################################################
+      ###############                           #####################
+      ###############          Validates        #####################
+      ###############                           #####################
+      ###############################################################
+   */
+
+  private void validate(QueryInput input){
+    //authKey에 대한 검증
+    ApiInfo apiInfo = apiInfoRepository.findById(input.getApiId())
+        .orElseThrow(() -> new ApiException(API_NOT_FOUND));
+
+    ApiKey apiKey = apiKeyRepository.findByApiInfoAndAuthKey(apiInfo, input.getAuthKey())
+        .orElseThrow(() -> new ApiPermissionException(API_KEY_NOT_ISSUED));
+
+    //쿼리 파라미터에 대한 검증
+    Map<String, ApiQueryType> apiQueryTypeMap = apiInfo.getQueryParameter();
+
+    for(String fieldName : input.getQueryParameter().keySet()){
+      if(!apiQueryTypeMap.containsKey(fieldName)){
+        throw new ApiException(QUERY_PARAMETER_CANNOT_MATCH);
+      }
+    }
+  }
+
+  /*
+      ###############################################################
+      ###############                           #####################
+      ###############          Utils            #####################
+      ###############                           #####################
+      ###############################################################
+   */
+
+  private Query getQuery(QueryInput input){
+
+    Query query = new Query();
+
+    ApiInfo apiInfo = apiInfoRepository.findById(input.getApiId())
+        .orElseThrow(() -> new ApiException(API_NOT_FOUND));
+
+    Map<String, ApiStructureType> structureTypeMap = apiInfo.getSchemaStructure();
+    Map<String, ApiQueryType> queryTypeMap = apiInfo.getQueryParameter();
+
+    List<String> fullTextValue = new ArrayList<>();
+    List<String> fullTextField = new ArrayList<>();
+
+    for(Map.Entry<String, Object> inputQueryParam : input.getQueryParameter().entrySet()){
+      String field = inputQueryParam.getKey();
+      ApiStructureType structureType = structureTypeMap.get(field);
+
+      Object value = "";
+
+      try {
+        switch (structureType) {
+          case INTEGER:
+            value = Long.parseLong(inputQueryParam.getValue().toString());
+            break;
+          case FLOAT:
+            value = Double.parseDouble(inputQueryParam.getValue().toString());
+            break;
+          case DATE:
+            value = LocalDate.parse(inputQueryParam.getValue().toString());
+            break;
+          default:
+            value = inputQueryParam.getValue();
+        }
+      }catch (Exception e){
+        throw new ApiException(QUERY_PARAMETER_CANNOT_MATCH);
+      }
+
+      ApiQueryType queryType = queryTypeMap.get(field);
+
+      switch (queryType){
+        case INCLUDE:
+          fullTextField.add(field);
+          fullTextValue.add(value.toString());
+          break;
+        case START:
+          query.addCriteria(Criteria.where(field).regex("^" + value));
+          break;
+        case EQUAL:
+          query.addCriteria(Criteria.where(field).is(value));
+          break;
+        case GT:
+          query.addCriteria(Criteria.where(field).gt(value));
+          break;
+        case GTE:
+          query.addCriteria(Criteria.where(field).gte(value));
+          break;
+        case LT:
+          query.addCriteria(Criteria.where(field).lt(value));
+          break;
+        case LTE:
+          query.addCriteria(Criteria.where(field).lte(value));
+          break;
+      }
+    }
+
+    if (fullTextField.size() == 0){
+      return query;
+    }
+
+    StringBuilder fullTextSearchWord = new StringBuilder();
+    for (int i = 0; i < fullTextValue.size(); i++) {
+      fullTextSearchWord.append(fullTextValue.get(i));
+
+      if(i == fullTextValue.size()-1){
+        break;
+      }
+      fullTextSearchWord.append(" ");
+    }
+
+    TextCriteria textCriteria = TextCriteria.forDefaultLanguage().matchingAny(
+        fullTextSearchWord.toString());
+    query.addCriteria(textCriteria);
+
+    //full-text-search - field filtering
+    List<Criteria> fieldFilterCriteria = new ArrayList<Criteria>();
+
+    for (int i = 0; i < fullTextField.size(); i++) {
+      fieldFilterCriteria.add(Criteria.where(fullTextField.get(i)).regex(fullTextValue.get(i)));
+    }
+
+    query.addCriteria(new Criteria().orOperator(fieldFilterCriteria));
+    return query;
+  }
+}

--- a/api/src/main/java/com/jhsfully/api/util/MemberUtil.java
+++ b/api/src/main/java/com/jhsfully/api/util/MemberUtil.java
@@ -1,0 +1,31 @@
+package com.jhsfully.api.util;
+
+import org.springframework.security.core.context.SecurityContextHolder;
+
+/*
+    -1 is for unit-test
+ */
+public class MemberUtil {
+
+  public static Long getMemberId(){
+    if(SecurityContextHolder.getContext() == null){
+      return -1L;
+    }
+    if(SecurityContextHolder.getContext().getAuthentication() == null){
+      return -1L;
+    }
+    if(SecurityContextHolder.getContext().getAuthentication().getName() == null){
+      return -1L;
+    }
+
+    String stringMemberId = SecurityContextHolder.getContext().getAuthentication().getName();
+    long result;
+    try{
+      result = Long.parseLong(stringMemberId);
+    }catch (Exception e){
+      result = -1L;
+    }
+    return result;
+  }
+
+}

--- a/domain/src/main/java/com/jhsfully/domain/converter/JsonConverter.java
+++ b/domain/src/main/java/com/jhsfully/domain/converter/JsonConverter.java
@@ -2,6 +2,8 @@ package com.jhsfully.domain.converter;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jhsfully.domain.type.ApiQueryType;
+import com.jhsfully.domain.type.ApiStructureType;
 import java.util.Map;
 import javax.persistence.AttributeConverter;
 import javax.persistence.Converter;
@@ -27,7 +29,21 @@ public class JsonConverter implements AttributeConverter<Map<String, Object>, St
   @Override
   public Map<String, Object> convertToEntityAttribute(String dbData) {
     try {
-      return objectMapper.readValue(dbData, Map.class);
+      Map<String, Object> outData = objectMapper.readValue(dbData, Map.class);
+
+      //String으로 받아오는 이슈때문에, 형변환이 필요함.
+      for(String key : outData.keySet()){
+        Object value = outData.get(key);
+
+        try{
+          value = ApiStructureType.valueOf((String) value);
+        }catch (IllegalArgumentException e){
+          value = ApiQueryType.valueOf((String) value);
+        }
+
+        outData.put(key, value);
+      }
+      return outData;
     } catch (JsonProcessingException e) {
       throw new RuntimeException(e);
     }

--- a/domain/src/main/java/com/jhsfully/domain/entity/ApiKey.java
+++ b/domain/src/main/java/com/jhsfully/domain/entity/ApiKey.java
@@ -1,5 +1,6 @@
 package com.jhsfully.domain.entity;
 
+import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
@@ -27,5 +28,6 @@ public class ApiKey {
   private Member member;
   @ManyToOne
   private ApiInfo apiInfo;
+  @Column(nullable = false, unique = true)
   private String authKey;
 }

--- a/domain/src/main/java/com/jhsfully/domain/repository/ApiKeyRepository.java
+++ b/domain/src/main/java/com/jhsfully/domain/repository/ApiKeyRepository.java
@@ -1,0 +1,15 @@
+package com.jhsfully.domain.repository;
+
+import com.jhsfully.domain.entity.ApiInfo;
+import com.jhsfully.domain.entity.ApiKey;
+import com.jhsfully.domain.entity.Member;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ApiKeyRepository extends JpaRepository<ApiKey, Long> {
+  Optional<ApiKey> findByApiInfoAndMember(ApiInfo apiInfo, Member member);
+
+  Optional<ApiKey> findByApiInfoAndAuthKey(ApiInfo apiInfo, String authKey);
+}

--- a/domain/src/main/java/com/jhsfully/domain/repository/ApiUserPermissionRepository.java
+++ b/domain/src/main/java/com/jhsfully/domain/repository/ApiUserPermissionRepository.java
@@ -1,0 +1,13 @@
+package com.jhsfully.domain.repository;
+
+import com.jhsfully.domain.entity.ApiInfo;
+import com.jhsfully.domain.entity.ApiUserPermission;
+import com.jhsfully.domain.entity.Member;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ApiUserPermissionRepository extends JpaRepository<ApiUserPermission, Long> {
+  Optional<ApiUserPermission> findByApiInfoAndMember(ApiInfo apiInfo, Member member);
+}

--- a/domain/src/main/java/com/jhsfully/domain/type/errortype/ApiErrorType.java
+++ b/domain/src/main/java/com/jhsfully/domain/type/errortype/ApiErrorType.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum ApiErrorType {
 
+  API_NOT_FOUND("존재하지 않는 API입니다."),
   DUPLICATED_SCHEMA("중복된 스키마 필드는 생성이 불가능합니다."),
   DUPLICATED_QUERY_PARAMETER("중복된 쿼리파라미터는 생성이 불가능합니다."),
   QUERY_PARAMETER_NOT_INCLUDE_SCHEMA("스키마에 대한 쿼리파라미터가 아닙니다."),

--- a/domain/src/main/java/com/jhsfully/domain/type/errortype/ApiPermissionErrorType.java
+++ b/domain/src/main/java/com/jhsfully/domain/type/errortype/ApiPermissionErrorType.java
@@ -1,0 +1,13 @@
+package com.jhsfully.domain.type.errortype;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ApiPermissionErrorType {
+  USER_HAS_NOT_API("해당 API에 대한 권한이 없습니다."),
+  API_KEY_NOT_ISSUED("발급된 API가 없습니다."),
+  API_KEY_ALREADY_ISSUED("이미 API키가 발급되었습니다.");
+  private final String message;
+}


### PR DESCRIPTION
- auth_key를 획득/발급/재발급 하는 로직 생성함.
- query 컨트롤러를 생성하여, 데이터에 조건에 맞추어 질의할 수 있도록 함.

### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**

**TO-BE**
- 접근 가능한, OpenAPI에 대해 authkey를 발급받을 수 있도록 하였습니다.
- /query/{apiId}/{authKey}/{pageSize}/{pageIdx}?query1=value.... 로 요청하면, 이에 맞는 응답 반환하도록 하였습니다.

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [ ] API 테스트 