### PR TITLE
feat : 등급에 대한 제약 사항을 추가함.

### DIFF
--- a/api/src/main/java/com/jhsfully/api/restcontroller/AdminController.java
+++ b/api/src/main/java/com/jhsfully/api/restcontroller/AdminController.java
@@ -3,7 +3,9 @@ package com.jhsfully.api.restcontroller;
 import com.jhsfully.api.security.TokenProvider;
 import com.jhsfully.domain.entity.Member;
 import com.jhsfully.domain.repository.MemberRepository;
+import org.bson.Document;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -33,4 +35,16 @@ public class AdminController {
     );
   }
 
+  @Autowired
+  private MongoTemplate mongoTemplate;
+  @GetMapping("/test/dbsize")
+  public ResponseEntity<?> getDbSize(){
+    // 실행할 명령
+    Document command = new Document("collStats", "5eabfda2108d46aeba7bf1e9d2628e6c");
+
+    // 명령 실행 및 결과 출력
+    Document result = mongoTemplate.getDb().runCommand(command);
+//    System.out.println(result.toJson());
+    return ResponseEntity.ok(result);
+  }
 }

--- a/api/src/main/java/com/jhsfully/api/service/impl/ApiInviteServiceImpl.java
+++ b/api/src/main/java/com/jhsfully/api/service/impl/ApiInviteServiceImpl.java
@@ -1,5 +1,6 @@
 package com.jhsfully.api.service.impl;
 
+import static com.jhsfully.domain.type.errortype.ApiErrorType.API_IS_DISABLED;
 import static com.jhsfully.domain.type.errortype.ApiErrorType.API_NOT_FOUND;
 import static com.jhsfully.domain.type.errortype.ApiInviteErrorType.CANNOT_ASSIGN_INVITE_NOT_TARGET;
 import static com.jhsfully.domain.type.errortype.ApiInviteErrorType.CANNOT_INVITE_ALREADY_HAS_PERMISSION;
@@ -28,6 +29,7 @@ import com.jhsfully.domain.repository.ApiUserPermissionRepository;
 import com.jhsfully.domain.repository.MemberRepository;
 import com.jhsfully.domain.type.ApiRequestStateType;
 import com.jhsfully.domain.type.ApiRequestType;
+import com.jhsfully.domain.type.ApiState;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Objects;
@@ -171,6 +173,12 @@ public class ApiInviteServiceImpl implements ApiInviteService {
    */
 
   private void validateApiInvite(ApiInfo apiInfo, Member ownerMember, Member targetMember) {
+
+    //API가 비활성화 상태인 경우 throw
+    if(apiInfo.getApiState() == ApiState.DISABLED){
+      throw new ApiException(API_IS_DISABLED);
+    }
+
     //소유주가 아닌 경우 throw
     if(!Objects.equals(apiInfo.getMember().getId(), ownerMember.getId())){
       throw new ApiInviteException(CANNOT_INVITE_NOT_API_OWNER);
@@ -190,6 +198,12 @@ public class ApiInviteServiceImpl implements ApiInviteService {
   }
 
   private static void validateApiInviteAssign(Member member, ApiRequestInvite invite) {
+
+    //API가 비활성화 상태인 경우 throw
+    if(invite.getApiInfo().getApiState() == ApiState.DISABLED){
+      throw new ApiException(API_IS_DISABLED);
+    }
+
     //초대 받은이와 수락하는 이가 다르면, throw
     if(!Objects.equals(invite.getMember().getId(), member.getId())){
       throw new ApiInviteException(CANNOT_ASSIGN_INVITE_NOT_TARGET);
@@ -207,6 +221,7 @@ public class ApiInviteServiceImpl implements ApiInviteService {
   }
 
   private static void validateApiInviteReject(Member member, ApiRequestInvite invite) {
+
     //초대 받은이와 거절하는 이가 다르면, throw
     if(!Objects.equals(invite.getMember().getId(), member.getId())){
       throw new ApiInviteException(CANNOT_REJECT_INVITE_NOT_TARGET);

--- a/api/src/main/java/com/jhsfully/api/service/impl/ApiPermissionServiceImpl.java
+++ b/api/src/main/java/com/jhsfully/api/service/impl/ApiPermissionServiceImpl.java
@@ -1,5 +1,6 @@
 package com.jhsfully.api.service.impl;
 
+import static com.jhsfully.domain.type.errortype.ApiErrorType.API_IS_DISABLED;
 import static com.jhsfully.domain.type.errortype.ApiErrorType.API_NOT_FOUND;
 import static com.jhsfully.domain.type.errortype.ApiPermissionErrorType.ALREADY_HAS_PERMISSION;
 import static com.jhsfully.domain.type.errortype.ApiPermissionErrorType.API_KEY_ALREADY_ISSUED;
@@ -28,6 +29,7 @@ import com.jhsfully.domain.repository.ApiPermissionDetailRepository;
 import com.jhsfully.domain.repository.ApiUserPermissionRepository;
 import com.jhsfully.domain.repository.MemberRepository;
 import com.jhsfully.domain.type.ApiPermissionType;
+import com.jhsfully.domain.type.ApiState;
 import java.util.Objects;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -233,6 +235,11 @@ public class ApiPermissionServiceImpl implements ApiPermissionService {
 
     ApiInfo apiInfo = apiInfoRepository.findById(apiId)
         .orElseThrow(() -> new ApiException(API_NOT_FOUND));
+
+    //API가 비활성 상태라면, 발급 불가
+    if(apiInfo.getApiState() == ApiState.DISABLED){
+      throw new ApiException(API_IS_DISABLED);
+    }
 
     //자신이 소유하고 있는 API라면, 바로 리턴.
     if(Objects.equals(apiInfo.getMember().getId(), member.getId())){

--- a/api/src/main/java/com/jhsfully/api/service/impl/QueryServiceImpl.java
+++ b/api/src/main/java/com/jhsfully/api/service/impl/QueryServiceImpl.java
@@ -1,5 +1,6 @@
 package com.jhsfully.api.service.impl;
 
+import static com.jhsfully.domain.type.errortype.ApiErrorType.API_IS_DISABLED;
 import static com.jhsfully.domain.type.errortype.ApiErrorType.API_NOT_FOUND;
 import static com.jhsfully.domain.type.errortype.ApiErrorType.QUERY_PARAMETER_CANNOT_MATCH;
 import static com.jhsfully.domain.type.errortype.ApiPermissionErrorType.API_KEY_NOT_ISSUED;
@@ -13,6 +14,7 @@ import com.jhsfully.domain.entity.ApiInfo;
 import com.jhsfully.domain.repository.ApiInfoRepository;
 import com.jhsfully.domain.repository.ApiKeyRepository;
 import com.jhsfully.domain.type.ApiQueryType;
+import com.jhsfully.domain.type.ApiState;
 import com.jhsfully.domain.type.ApiStructureType;
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -70,10 +72,16 @@ public class QueryServiceImpl implements QueryService {
    */
 
   private void validate(QueryInput input){
-    //authKey에 대한 검증
+
     ApiInfo apiInfo = apiInfoRepository.findById(input.getApiId())
         .orElseThrow(() -> new ApiException(API_NOT_FOUND));
 
+    //사용가능한 상태인지 검증.
+    if(apiInfo.getApiState() == ApiState.DISABLED){
+      throw new ApiException(API_IS_DISABLED);
+    }
+
+    //authKey에 대한 검증
     apiKeyRepository.findByApiInfoAndAuthKey(apiInfo, input.getAuthKey())
         .orElseThrow(() -> new ApiPermissionException(API_KEY_NOT_ISSUED));
 

--- a/api/src/main/java/com/jhsfully/api/util/MongoUtil.java
+++ b/api/src/main/java/com/jhsfully/api/util/MongoUtil.java
@@ -1,0 +1,17 @@
+package com.jhsfully.api.util;
+
+import org.bson.Document;
+import org.springframework.data.mongodb.core.MongoTemplate;
+
+public class MongoUtil {
+
+  private final static String MONGO_STAT_COMMAND = "collStats";
+  private final static String MONGO_STORAGE_PROPERTY = "storageSize";
+
+  public static long getDbSizeByCollection(MongoTemplate mongoTemplate, String collectionName){
+    return Long.parseLong(mongoTemplate.getDb()
+        .runCommand(new Document(MONGO_STAT_COMMAND, collectionName))
+        .get(MONGO_STORAGE_PROPERTY).toString());
+  }
+
+}

--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -6,6 +6,11 @@ spring:
     pathmatch:
       matching-strategy: ant_path_matcher
 
+  servlet:
+    multipart:
+      max-file-size: 100MB
+      max-request-size: 100MB
+
   payment:
       kakao:
         request-url: https://kapi.kakao.com/v1/payment/ready

--- a/domain/src/main/java/com/jhsfully/domain/repository/ApiInfoRepository.java
+++ b/domain/src/main/java/com/jhsfully/domain/repository/ApiInfoRepository.java
@@ -11,6 +11,8 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface ApiInfoRepository extends JpaRepository<ApiInfo, Long> {
 
+  int countByMember(Member member);
+
   @Modifying
   @Query(
       "UPDATE ApiInfo api set api.apiState='DISABLED' where api.member= :member"

--- a/domain/src/main/java/com/jhsfully/domain/type/errortype/ApiErrorType.java
+++ b/domain/src/main/java/com/jhsfully/domain/type/errortype/ApiErrorType.java
@@ -19,6 +19,14 @@ public enum ApiErrorType {
   VALUE_STRUCTURE_IS_DIFFERENT("입력된 데이터의 자료구조가 다릅니다."),
   DOES_NOT_EXCEL_FILE("업로드 된 파일은 엑셀파일이 아닙니다."),
   FILE_PARSE_ERROR("파일을 읽는 중에 오류가 발생하였습니다."),
+  SCHEMA_COUNT_IS_ZERO("정의된 스키마 구조가 존재하지 않습니다."),
+  OVERFLOW_MAX_FILE_SIZE("지정된 파일 용량을 초과하였습니다."),
+  OVERFLOW_MAX_DB_SIZE("지정된 DB 용량을 초과하였습니다."),
+  OVERFLOW_API_MAX_COUNT("생성 가능한 API갯수를 초과하였습니다."),
+  OVERFLOW_FIELD_MAX_COUNT("생성 가능한 필드 갯수를 초과하였습니다."),
+  OVERFLOW_QUERY_MAX_COUNT("생성 가능한 검색 질의 인수 갯수를 초과하였습니다."),
+  OVERFLOW_RECORD_MAX_COUNT("생성 가능한 레코드 갯수를 초과하였습니다."),
+  API_IS_DISABLED("해당 API는 현재 비활성화 상태입니다."),
   ;
   private final String message;
 }

--- a/domain/src/main/java/com/jhsfully/domain/type/errortype/GradeErrorType.java
+++ b/domain/src/main/java/com/jhsfully/domain/type/errortype/GradeErrorType.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum GradeErrorType {
   GRADE_NOT_FOUND("존재하지 않는 등급입니다."),
+  MEMBER_HAS_NOT_GRADE("등급을 소유하고 있지 않습니다. 고객센터로 연락바랍니다."),
   ;
   private final String message;
 }


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**

**TO-BE**
- 등급에 따른 제약 사항을 추가하였음.
- MongoDB Collection의 StorageSize를 추출하기 위해, runCommand()를 수행함.
- 비활성 여부에 따른, API접근 제약 추가함.

**추후에 추가 조치 사항**
- 몽고DB에 data가 remove되어도, db의 용량이 줄어들지 않음.
- 이는 관리자 권한으로 컬렉션 마다, compact()를 수행해주어야 한다고 함.
- 추후에, 배치 모듈을 구현할 경우에, 이에 대한 처리를 해줄 예정.

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [x] API 테스트 