### PR TITLE
타입 안전성 개선, 파일 검사 로직 개선, Model 롬복 어노테이션 정리

### DIFF
--- a/api/src/main/java/com/jhsfully/api/model/api/ApiSearchResponse.java
+++ b/api/src/main/java/com/jhsfully/api/model/api/ApiSearchResponse.java
@@ -5,12 +5,8 @@ import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 @Getter
-@Setter
-@NoArgsConstructor
 @AllArgsConstructor
 @Builder
 public class ApiSearchResponse {

--- a/api/src/main/java/com/jhsfully/api/model/api/CreateApiInput.java
+++ b/api/src/main/java/com/jhsfully/api/model/api/CreateApiInput.java
@@ -14,9 +14,11 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.springframework.web.multipart.MultipartFile;
 
+/*
+    ModelAttribute로 입력받기 위해 Setter를 유지.
+ */
 @Getter
 @Setter
-@NoArgsConstructor
 @AllArgsConstructor
 @Builder
 public class CreateApiInput {

--- a/api/src/main/java/com/jhsfully/api/model/api/DeleteApiDataInput.java
+++ b/api/src/main/java/com/jhsfully/api/model/api/DeleteApiDataInput.java
@@ -2,12 +2,8 @@ package com.jhsfully.api.model.api;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 @Getter
-@Setter
-@NoArgsConstructor
 @AllArgsConstructor
 public class DeleteApiDataInput {
   private long apiId;

--- a/api/src/main/java/com/jhsfully/api/model/api/InsertApiDataInput.java
+++ b/api/src/main/java/com/jhsfully/api/model/api/InsertApiDataInput.java
@@ -3,12 +3,8 @@ package com.jhsfully.api.model.api;
 import java.util.Map;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 @Getter
-@Setter
-@NoArgsConstructor
 @AllArgsConstructor
 public class InsertApiDataInput {
   private long apiId;

--- a/api/src/main/java/com/jhsfully/api/model/api/UpdateApiDataInput.java
+++ b/api/src/main/java/com/jhsfully/api/model/api/UpdateApiDataInput.java
@@ -3,12 +3,8 @@ package com.jhsfully.api.model.api;
 import java.util.Map;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 @Getter
-@Setter
-@NoArgsConstructor
 @AllArgsConstructor
 public class UpdateApiDataInput {
   private long apiId;

--- a/api/src/main/java/com/jhsfully/api/model/auth/TokenInput.java
+++ b/api/src/main/java/com/jhsfully/api/model/auth/TokenInput.java
@@ -2,11 +2,8 @@ package com.jhsfully.api.model.auth;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 @Getter
-@NoArgsConstructor
 @AllArgsConstructor
 public class TokenInput {
   private String refreshToken;

--- a/api/src/main/java/com/jhsfully/api/model/auth/TokenResponse.java
+++ b/api/src/main/java/com/jhsfully/api/model/auth/TokenResponse.java
@@ -2,12 +2,8 @@ package com.jhsfully.api.model.auth;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 @Getter
-@Setter
-@NoArgsConstructor
 @AllArgsConstructor
 public class TokenResponse {
   private String accessToken;

--- a/api/src/main/java/com/jhsfully/api/model/dto/ApiInfoDto.java
+++ b/api/src/main/java/com/jhsfully/api/model/dto/ApiInfoDto.java
@@ -9,13 +9,11 @@ import java.util.Map;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 
 public class ApiInfoDto {
 
   @Getter
-  @NoArgsConstructor
   @AllArgsConstructor
   @Builder
   public static class ApiInfoDetailResponse{

--- a/api/src/main/java/com/jhsfully/api/model/dto/ApiRequestInviteDto.java
+++ b/api/src/main/java/com/jhsfully/api/model/dto/ApiRequestInviteDto.java
@@ -7,10 +7,8 @@ import java.util.Objects;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor
 @AllArgsConstructor
 @Builder
 public class ApiRequestInviteDto {

--- a/api/src/main/java/com/jhsfully/api/model/dto/BlackListDto.java
+++ b/api/src/main/java/com/jhsfully/api/model/dto/BlackListDto.java
@@ -5,10 +5,8 @@ import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor
 @AllArgsConstructor
 @Builder
 public class BlackListDto {

--- a/api/src/main/java/com/jhsfully/api/model/dto/PaymentDto.java
+++ b/api/src/main/java/com/jhsfully/api/model/dto/PaymentDto.java
@@ -6,10 +6,8 @@ import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor
 @AllArgsConstructor
 @Builder
 public class PaymentDto {

--- a/api/src/main/java/com/jhsfully/api/model/dto/PermissionDto.java
+++ b/api/src/main/java/com/jhsfully/api/model/dto/PermissionDto.java
@@ -7,10 +7,8 @@ import java.util.List;
 import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.Setter;
 
 @Getter
-@Setter
 @AllArgsConstructor
 public class PermissionDto {
   private long permissionId;

--- a/api/src/main/java/com/jhsfully/api/model/history/HistoryResponse.java
+++ b/api/src/main/java/com/jhsfully/api/model/history/HistoryResponse.java
@@ -1,10 +1,10 @@
 package com.jhsfully.api.model.history;
 
 import java.util.List;
-import java.util.Map;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import org.bson.Document;
 
 @Getter
 @AllArgsConstructor
@@ -13,6 +13,6 @@ public class HistoryResponse {
 
   private long totalCount;
   private int dataCount;
-  private List<Map> histories;
+  private List<Document> histories;
 
 }

--- a/api/src/main/java/com/jhsfully/api/model/history/HistoryResponse.java
+++ b/api/src/main/java/com/jhsfully/api/model/history/HistoryResponse.java
@@ -5,10 +5,8 @@ import java.util.Map;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor
 @AllArgsConstructor
 @Builder
 public class HistoryResponse {

--- a/api/src/main/java/com/jhsfully/api/model/payment/PaymentResponse.java
+++ b/api/src/main/java/com/jhsfully/api/model/payment/PaymentResponse.java
@@ -5,12 +5,8 @@ import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 @Getter
-@Setter
-@NoArgsConstructor
 @AllArgsConstructor
 @Builder
 public class PaymentResponse {

--- a/api/src/main/java/com/jhsfully/api/model/permission/AuthKeyResponse.java
+++ b/api/src/main/java/com/jhsfully/api/model/permission/AuthKeyResponse.java
@@ -2,12 +2,8 @@ package com.jhsfully.api.model.permission;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 @Getter
-@Setter
-@NoArgsConstructor
 @AllArgsConstructor
 public class AuthKeyResponse {
   private String authKey;

--- a/api/src/main/java/com/jhsfully/api/model/permission/PermissionResponse.java
+++ b/api/src/main/java/com/jhsfully/api/model/permission/PermissionResponse.java
@@ -1,17 +1,12 @@
 package com.jhsfully.api.model.permission;
 
-import java.util.List;
-
 import com.jhsfully.api.model.dto.PermissionDto;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 @Getter
-@Setter
-@NoArgsConstructor
 @AllArgsConstructor
 @Builder
 public class PermissionResponse {

--- a/api/src/main/java/com/jhsfully/api/model/query/QueryInput.java
+++ b/api/src/main/java/com/jhsfully/api/model/query/QueryInput.java
@@ -4,10 +4,8 @@ import java.util.Map;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor
 @AllArgsConstructor
 @Builder
 public class QueryInput {

--- a/api/src/main/java/com/jhsfully/api/model/query/QueryResponse.java
+++ b/api/src/main/java/com/jhsfully/api/model/query/QueryResponse.java
@@ -1,10 +1,10 @@
 package com.jhsfully.api.model.query;
 
 import java.util.List;
-import java.util.Map;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import org.bson.Document;
 
 @Getter
 @AllArgsConstructor
@@ -13,6 +13,6 @@ public class QueryResponse {
 
   private long totalCount;
   private long dataCount;
-  private List<Map> dataList;
+  private List<Document> dataList;
 
 }

--- a/api/src/main/java/com/jhsfully/api/model/query/QueryResponse.java
+++ b/api/src/main/java/com/jhsfully/api/model/query/QueryResponse.java
@@ -5,12 +5,8 @@ import java.util.Map;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 @Getter
-@Setter
-@NoArgsConstructor
 @AllArgsConstructor
 @Builder
 public class QueryResponse {

--- a/api/src/main/java/com/jhsfully/api/service/impl/ApiHistoryServiceImpl.java
+++ b/api/src/main/java/com/jhsfully/api/service/impl/ApiHistoryServiceImpl.java
@@ -79,7 +79,7 @@ public class ApiHistoryServiceImpl implements ApiHistoryService {
     query.with(pageable);
 
     //데이터 질의
-    List<Map> queriedDataList = mongoTemplate.find(query, Map.class, apiInfo.getHistoryCollectionName())
+    List<Document> queriedDataList = mongoTemplate.find(query, Document.class, apiInfo.getHistoryCollectionName())
         .stream()
         .peek(x -> x.put(MONGODB_ID, x.get(MONGODB_ID).toString()))
         .collect(Collectors.toList());

--- a/api/src/main/java/com/jhsfully/api/service/impl/ApiServiceImpl.java
+++ b/api/src/main/java/com/jhsfully/api/service/impl/ApiServiceImpl.java
@@ -15,6 +15,7 @@ import static com.jhsfully.domain.type.errortype.ApiErrorType.DOES_NOT_EXCEL_FIL
 import static com.jhsfully.domain.type.errortype.ApiErrorType.DUPLICATED_QUERY_PARAMETER;
 import static com.jhsfully.domain.type.errortype.ApiErrorType.DUPLICATED_SCHEMA;
 import static com.jhsfully.domain.type.errortype.ApiErrorType.FIELD_WAS_NOT_DEFINITION_IN_SCHEMA;
+import static com.jhsfully.domain.type.errortype.ApiErrorType.FILE_NAME_IS_NULL;
 import static com.jhsfully.domain.type.errortype.ApiErrorType.FILE_PARSE_ERROR;
 import static com.jhsfully.domain.type.errortype.ApiErrorType.OVERFLOW_API_MAX_COUNT;
 import static com.jhsfully.domain.type.errortype.ApiErrorType.OVERFLOW_FIELD_MAX_COUNT;
@@ -178,10 +179,12 @@ public class ApiServiceImpl implements ApiService {
       throw new ApiException(FILE_PARSE_ERROR);
     }
 
-    /*
-        상단에서, 이미 검사를 마쳤기 때문에, split해서 확장자를 가져올 수 있음.
-     */
-    String fileExtension = file.getOriginalFilename().split("\\.")[1];
+    if(file.getOriginalFilename() == null) {
+      throw new ApiException(FILE_NAME_IS_NULL);
+    }
+
+    String[] periodSeparated = file.getOriginalFilename().split("\\.");
+    String fileExtension = periodSeparated[periodSeparated.length-1];
     String filepath = EXCEL_STORAGE_PATH + "/" + fileName + "." + fileExtension;
     try {
       File newFile = new File(filepath);

--- a/api/src/main/java/com/jhsfully/api/service/impl/ApiServiceImpl.java
+++ b/api/src/main/java/com/jhsfully/api/service/impl/ApiServiceImpl.java
@@ -232,7 +232,7 @@ public class ApiServiceImpl implements ApiService {
 
     InsertOneResult result = collection.insertOne(document);
 
-    input.getInsertData().put(MONGODB_ID, result.getInsertedId().asObjectId().getValue());
+    input.getInsertData().put(MONGODB_ID, Objects.requireNonNull(result.getInsertedId()).asObjectId().getValue());
 
     //히스토리 로그 남기기.
     apiHistoryService.writeInsertHistory(
@@ -271,7 +271,7 @@ public class ApiServiceImpl implements ApiService {
     }
 
     //기존 데이터 가져오기.
-    Map<String, Object> originalData = mongoTemplate.findOne(query, Map.class, apiInfo.getDataCollectionName());
+    Document originalData = mongoTemplate.findOne(query, Document.class, apiInfo.getDataCollectionName());
 
     //업데이트 할 데이터 설정.
     Update update = new Update();
@@ -312,7 +312,7 @@ public class ApiServiceImpl implements ApiService {
     Query query = new Query(Criteria.where(MONGODB_ID).is(new ObjectId(input.getDataId())));
 
     //기존 데이터 가져오기.
-    Map<String, Object> originalData = mongoTemplate.findOne(query, Map.class, apiInfo.getDataCollectionName());
+    Document originalData = mongoTemplate.findOne(query, Document.class, apiInfo.getDataCollectionName());
 
     //id가 존재하는지 확인하기.
     if(!mongoTemplate.exists(query, apiInfo.getDataCollectionName())){

--- a/api/src/main/java/com/jhsfully/api/service/impl/QueryServiceImpl.java
+++ b/api/src/main/java/com/jhsfully/api/service/impl/QueryServiceImpl.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.bson.Document;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.mongodb.core.MongoTemplate;
@@ -57,7 +58,7 @@ public class QueryServiceImpl implements QueryService {
 
     query.with(pageable);
 
-    List<Map> results = mongoTemplate.find(query, Map.class, apiInfo.getDataCollectionName())
+    List<Document> results = mongoTemplate.find(query, Document.class, apiInfo.getDataCollectionName())
         .stream()
         .peek(x -> x.put(MONGODB_ID, x.get(MONGODB_ID).toString()))
         .collect(Collectors.toList());

--- a/api/src/main/java/com/jhsfully/api/util/FileUtil.java
+++ b/api/src/main/java/com/jhsfully/api/util/FileUtil.java
@@ -12,25 +12,16 @@ public class FileUtil {
 
   public static boolean validFileExtension(MultipartFile file) throws IOException {
 
-    InputStream inputStream = file.getInputStream();
-
-    try{
+    try(InputStream inputStream = file.getInputStream()){
       String mimeType = tika.detect(inputStream);
-
-      if (EXCEL_MIME_TYPE.equals(mimeType)){
-
-        String extension = file.getOriginalFilename().split("\\.")[1];
-
+      if (EXCEL_MIME_TYPE.equals(mimeType) &&
+        file.getOriginalFilename() != null){
+        String[] periodSeparated = file.getOriginalFilename().split("\\.");
+        String extension = periodSeparated[periodSeparated.length-1];
         if(extension.equals("xlsx") || extension.equals("xls")){
           return true;
         }
-
       }
-
-    }catch (IOException e){
-      return false;
-    }finally {
-      inputStream.close();
     }
     return false;
   }

--- a/api/src/test/java/com/jhsfully/api/service/impl/ApiHistoryServiceImplTest.java
+++ b/api/src/test/java/com/jhsfully/api/service/impl/ApiHistoryServiceImplTest.java
@@ -93,10 +93,10 @@ class ApiHistoryServiceImplTest {
       ApiInfo apiInfo = getApiInfo();
       Member ownerMember = getOwnerMember();
 
-      Map<String, String> historyData = new HashMap<>();
+      Document historyData = new Document();
       historyData.put(MONGODB_ID, "12341234");
       historyData.put("test", "test");
-      List<Map> queriedDataList = new ArrayList<>(List.of(historyData));
+      List<Document> queriedDataList = new ArrayList<>(List.of(historyData));
 
       given(apiInfoRepository.findById(anyLong()))
           .willReturn(Optional.of(apiInfo));
@@ -107,7 +107,7 @@ class ApiHistoryServiceImplTest {
       given(mongoTemplate.count(any(), anyString()))
           .willReturn(1L);
 
-      given(mongoTemplate.find(any(), eq(Map.class), anyString()))
+      given(mongoTemplate.find(any(), eq(Document.class), anyString()))
           .willReturn(queriedDataList);
 
       //when
@@ -222,7 +222,7 @@ class ApiHistoryServiceImplTest {
           () -> assertEquals(nowTime, expectedDocument.get(MONGODB_AT_COL)),
           () -> assertEquals(ownerMember.getEmail(), expectedDocument.get(MONGODB_MEMBER_COL)),
           () -> assertEquals(INSERT.name(), expectedDocument.get(MONGODB_TYPE_COL)),
-          () -> assertEquals("test", ((Map)expectedDocument.get(MONGODB_NEW_COL)).get("test"))
+          () -> assertEquals("test", ((Map<?, ?>)expectedDocument.get(MONGODB_NEW_COL)).get("test"))
       );
     }
 
@@ -281,8 +281,8 @@ class ApiHistoryServiceImplTest {
           () -> assertEquals(nowTime, expectedDocument.get(MONGODB_AT_COL)),
           () -> assertEquals(ownerMember.getEmail(), expectedDocument.get(MONGODB_MEMBER_COL)),
           () -> assertEquals(UPDATE.name(), expectedDocument.get(MONGODB_TYPE_COL)),
-          () -> assertEquals("original", ((Map)expectedDocument.get(MONGODB_ORIGINAL_COL)).get("original")),
-          () -> assertEquals("new", ((Map)expectedDocument.get(MONGODB_NEW_COL)).get("new"))
+          () -> assertEquals("original", ((Map<?, ?>)expectedDocument.get(MONGODB_ORIGINAL_COL)).get("original")),
+          () -> assertEquals("new", ((Map<?, ?>)expectedDocument.get(MONGODB_NEW_COL)).get("new"))
       );
     }
 
@@ -337,7 +337,7 @@ class ApiHistoryServiceImplTest {
           () -> assertEquals(nowTime, expectedDocument.get(MONGODB_AT_COL)),
           () -> assertEquals(ownerMember.getEmail(), expectedDocument.get(MONGODB_MEMBER_COL)),
           () -> assertEquals(DELETE.name(), expectedDocument.get(MONGODB_TYPE_COL)),
-          () -> assertEquals("test", ((Map)expectedDocument.get(MONGODB_ORIGINAL_COL)).get("test"))
+          () -> assertEquals("test", ((Map<?, ?>)expectedDocument.get(MONGODB_ORIGINAL_COL)).get("test"))
       );
     }
 

--- a/api/src/test/java/com/jhsfully/api/service/impl/QueryServiceImplTest.java
+++ b/api/src/test/java/com/jhsfully/api/service/impl/QueryServiceImplTest.java
@@ -28,6 +28,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import org.bson.Document;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -93,7 +94,7 @@ class QueryServiceImplTest {
     //given
     ApiInfo apiInfo = getApiInfo();
     String testAuthKey = "testAuthKey";
-    Map<String, Object> responseData = new HashMap<>();
+    Document responseData = new Document();
     responseData.put(MONGODB_ID, "2a2b4c");
     responseData.put("test", "test");
 

--- a/domain/src/main/java/com/jhsfully/domain/converter/JsonConverter.java
+++ b/domain/src/main/java/com/jhsfully/domain/converter/JsonConverter.java
@@ -1,9 +1,11 @@
 package com.jhsfully.domain.converter;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jhsfully.domain.type.ApiQueryType;
 import com.jhsfully.domain.type.ApiStructureType;
+import java.util.HashMap;
 import java.util.Map;
 import javax.persistence.AttributeConverter;
 import javax.persistence.Converter;
@@ -29,7 +31,8 @@ public class JsonConverter implements AttributeConverter<Map<String, Object>, St
   @Override
   public Map<String, Object> convertToEntityAttribute(String dbData) {
     try {
-      Map<String, Object> outData = objectMapper.readValue(dbData, Map.class);
+      TypeReference<HashMap<String,Object>> typeRef = new TypeReference<>() {};
+      Map<String, Object> outData = objectMapper.readValue(dbData, typeRef);
 
       //String으로 받아오는 이슈때문에, 형변환이 필요함.
       for(String key : outData.keySet()){

--- a/domain/src/main/java/com/jhsfully/domain/type/errortype/ApiErrorType.java
+++ b/domain/src/main/java/com/jhsfully/domain/type/errortype/ApiErrorType.java
@@ -23,6 +23,7 @@ public enum ApiErrorType {
   VALUE_STRUCTURE_IS_DIFFERENT("입력된 데이터의 자료구조가 다릅니다."),
   DOES_NOT_EXCEL_FILE("업로드 된 파일은 엑셀파일이 아닙니다."),
   FILE_PARSE_ERROR("파일을 읽는 중에 오류가 발생하였습니다."),
+  FILE_NAME_IS_NULL("파일이름이 존재하지 않습니다."),
   SCHEMA_COUNT_IS_ZERO("정의된 스키마 구조가 존재하지 않습니다."),
   OVERFLOW_MAX_FILE_SIZE("지정된 파일 용량을 초과하였습니다."),
   OVERFLOW_MAX_DB_SIZE("지정된 DB 용량을 초과하였습니다."),


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
- 기존에는 타입 안정성을 고려하지 않고, Map.class와 같은 코드를 사용하였음.
- JsonConverter에도 ObjectMapper에게 타입을 알려주지 않아서 경고 표시가 들어왔었음.
- Excel에 대한 파일명을 검사할 때, 확장자에만 Period(.)가 들어간다고 무조건 1번 인덱스가 확장자라고 추측함.

**TO-BE**
- Map.class를 Document.class로 수정하여, 안정성을 높였음.
- JsonConverter의 ObjectMapper에서도 TypeRef를 명시하여, 안정성을 높였음.
- 파일명에는 확장자아닌 곳에도 Period(.)가 올 가능성을 대비하여, split한 문자열에서 length - 1 부분을 확장자로 명시함.

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [X] 테스트 코드
- [X] API 테스트 