### PR TITLE
카카오 로그인 연동

### DIFF
--- a/api/src/main/java/com/jhsfully/api/configuration/SwaggerConfiguration.java
+++ b/api/src/main/java/com/jhsfully/api/configuration/SwaggerConfiguration.java
@@ -24,9 +24,8 @@ public class SwaggerConfiguration {
   public Docket api(){
     return new Docket(DocumentationType.SWAGGER_2)
         .apiInfo(apiInfo())
-        .securityContexts(Arrays.asList(securityContext("AccessToken"),
-            securityContext("RefreshToken")))
-        .securitySchemes(Arrays.asList(apiKey("AccessToken"), apiKey("RefreshToken")))
+        .securityContexts(Arrays.asList(securityContext("Authorization")))
+        .securitySchemes(Arrays.asList(apiKey("Authorization")))
         .select()
         .apis(RequestHandlerSelectors.basePackage("com.jhsfully.api"))
         .paths(PathSelectors.any())

--- a/api/src/main/java/com/jhsfully/api/configuration/WebMvcConfiguration.java
+++ b/api/src/main/java/com/jhsfully/api/configuration/WebMvcConfiguration.java
@@ -1,7 +1,19 @@
 package com.jhsfully.api.configuration;
 
+import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
+@Configuration
 public class WebMvcConfiguration implements WebMvcConfigurer {
 
+//    @Override
+//    public void addCorsMappings(CorsRegistry registry) {
+//        registry.addMapping("/**")
+//            .allowedOrigins("http://localhost:3000")
+//            .allowedMethods("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS")
+//            .allowedHeaders("*")
+//            .exposedHeaders("*")
+//            .allowCredentials(true)
+//            .maxAge(3600);
+//    }
 }

--- a/api/src/main/java/com/jhsfully/api/configuration/WebMvcConfiguration.java
+++ b/api/src/main/java/com/jhsfully/api/configuration/WebMvcConfiguration.java
@@ -1,19 +1,20 @@
 package com.jhsfully.api.configuration;
 
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
 public class WebMvcConfiguration implements WebMvcConfigurer {
 
-//    @Override
-//    public void addCorsMappings(CorsRegistry registry) {
-//        registry.addMapping("/**")
-//            .allowedOrigins("http://localhost:3000")
-//            .allowedMethods("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS")
-//            .allowedHeaders("*")
-//            .exposedHeaders("*")
-//            .allowCredentials(true)
-//            .maxAge(3600);
-//    }
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+            .allowedOrigins("http://localhost:3000")
+            .allowedMethods("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS")
+            .allowedHeaders("*")
+            .exposedHeaders("*")
+            .allowCredentials(true)
+            .maxAge(3600);
+    }
 }

--- a/api/src/main/java/com/jhsfully/api/model/dto/ProfileDto.java
+++ b/api/src/main/java/com/jhsfully/api/model/dto/ProfileDto.java
@@ -1,0 +1,26 @@
+package com.jhsfully.api.model.dto;
+
+import com.jhsfully.domain.entity.Member;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class ProfileDto {
+
+    private long memberId;
+    private String nickname;
+    private String email;
+    private String profileUrl;
+
+    public static ProfileDto of(Member entity) {
+        return ProfileDto.builder()
+            .memberId(entity.getId())
+            .nickname(entity.getNickname())
+            .email(entity.getEmail())
+            .profileUrl(entity.getProfileUrl())
+            .build();
+    }
+}

--- a/api/src/main/java/com/jhsfully/api/restcontroller/AuthController.java
+++ b/api/src/main/java/com/jhsfully/api/restcontroller/AuthController.java
@@ -5,7 +5,13 @@ import com.jhsfully.api.model.auth.TokenResponse;
 import com.jhsfully.api.service.AuthService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor

--- a/api/src/main/java/com/jhsfully/api/restcontroller/MemberController.java
+++ b/api/src/main/java/com/jhsfully/api/restcontroller/MemberController.java
@@ -1,0 +1,25 @@
+package com.jhsfully.api.restcontroller;
+
+import com.jhsfully.api.model.dto.ProfileDto;
+import com.jhsfully.api.service.MemberService;
+import com.jhsfully.api.util.MemberUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/member")
+public class MemberController {
+
+    private final MemberService memberService;
+
+    @GetMapping("/profile")
+    public ResponseEntity<ProfileDto> getProfile() {
+        long memberId = MemberUtil.getMemberId();
+        return ResponseEntity.ok(memberService.getProfile(memberId));
+    }
+
+}

--- a/api/src/main/java/com/jhsfully/api/security/JwtAuthenticationFilter.java
+++ b/api/src/main/java/com/jhsfully/api/security/JwtAuthenticationFilter.java
@@ -17,8 +17,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
 @Slf4j
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
-  public static final String ACCESS_TOKEN_HEADER = "AccessToken";
-  public static final String REFRESH_TOKEN_HEADER = "RefreshToken";
+  public static final String ACCESS_TOKEN_HEADER = "Authorization";
   public static final String TOKEN_PREFIX = "Bearer ";
   private final TokenProvider tokenProvider;
 

--- a/api/src/main/java/com/jhsfully/api/security/SecurityConfiguration.java
+++ b/api/src/main/java/com/jhsfully/api/security/SecurityConfiguration.java
@@ -1,6 +1,7 @@
 package com.jhsfully.api.security;
 
 import com.jhsfully.api.security.service.KakaoOauth2MemberService;
+import java.util.List;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -8,6 +9,9 @@ import org.springframework.security.config.annotation.web.configuration.WebSecur
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 @Configuration
 public class SecurityConfiguration{
@@ -36,6 +40,8 @@ public class SecurityConfiguration{
     http
         .httpBasic().disable()
         .csrf().disable()
+        .cors()
+        .and()
         .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
         .and()
         .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
@@ -49,6 +55,21 @@ public class SecurityConfiguration{
         .userService(kakaoOauth2MemberService);
 
     return http.build();
+  }
+
+  @Bean
+  public CorsConfigurationSource corsConfigurationSource() {
+    CorsConfiguration config = new CorsConfiguration();
+
+    config.setAllowCredentials(true);
+    config.setAllowedOrigins(List.of("http://localhost:3000"));
+    config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
+    config.setAllowedHeaders(List.of("*"));
+    config.setExposedHeaders(List.of("*"));
+
+    UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+    source.registerCorsConfiguration("/**", config);
+    return source;
   }
 
   @Bean

--- a/api/src/main/java/com/jhsfully/api/security/TokenProvider.java
+++ b/api/src/main/java/com/jhsfully/api/security/TokenProvider.java
@@ -8,6 +8,7 @@ import com.jhsfully.domain.type.errortype.AuthenticationErrorType;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
 import io.jsonwebtoken.SignatureAlgorithm;
 import java.util.Date;
 import java.util.List;
@@ -125,8 +126,12 @@ public class TokenProvider {
       return false;
     }
 
-    Claims claims = parseClaims(token);
-    return !claims.getExpiration().before(new Date());
+    try{
+      Claims claims = parseClaims(token);
+      return !claims.getExpiration().before(new Date());
+    } catch (MalformedJwtException e) {
+      return false;
+    }
   }
 
   //토큰 파싱

--- a/api/src/main/java/com/jhsfully/api/service/MemberService.java
+++ b/api/src/main/java/com/jhsfully/api/service/MemberService.java
@@ -1,0 +1,8 @@
+package com.jhsfully.api.service;
+
+import com.jhsfully.api.model.dto.ProfileDto;
+
+public interface MemberService {
+
+    ProfileDto getProfile(long memberId);
+}

--- a/api/src/main/java/com/jhsfully/api/service/impl/AuthServiceImpl.java
+++ b/api/src/main/java/com/jhsfully/api/service/impl/AuthServiceImpl.java
@@ -25,6 +25,7 @@ public class AuthServiceImpl implements AuthService {
   private final TokenProvider tokenProvider;
   private final HttpServletResponse response;
 
+
   @Override
   public void logout(String refreshTokenString) {
     refreshTokenRepository.findById(refreshTokenString).ifPresent(

--- a/api/src/main/java/com/jhsfully/api/service/impl/MemberServiceImpl.java
+++ b/api/src/main/java/com/jhsfully/api/service/impl/MemberServiceImpl.java
@@ -1,0 +1,24 @@
+package com.jhsfully.api.service.impl;
+
+import static com.jhsfully.domain.type.errortype.AuthenticationErrorType.AUTHENTICATION_USER_NOT_FOUND;
+
+import com.jhsfully.api.exception.AuthenticationException;
+import com.jhsfully.api.model.dto.ProfileDto;
+import com.jhsfully.api.service.MemberService;
+import com.jhsfully.domain.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MemberServiceImpl implements MemberService {
+
+    private final MemberRepository memberRepository;
+
+    @Override
+    public ProfileDto getProfile(long memberId) {
+        return ProfileDto.of(memberRepository.findById(memberId)
+            .orElseThrow(() -> new AuthenticationException(AUTHENTICATION_USER_NOT_FOUND)));
+    }
+
+}

--- a/react-app/package-lock.json
+++ b/react-app/package-lock.json
@@ -15,10 +15,12 @@
         "@types/node": "^16.18.68",
         "@types/react": "^18.2.45",
         "@types/react-dom": "^18.2.18",
+        "axios": "^1.6.2",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.21.0",
         "react-scripts": "5.0.1",
+        "recoil": "^0.7.7",
         "styled-components": "^6.1.1",
         "typescript": "^4.9.5",
         "web-vitals": "^2.1.4"
@@ -5113,6 +5115,29 @@
         "node": ">=4"
       }
     },
+    "node_modules/axios": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.2.tgz",
+      "integrity": "sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==",
+      "dependencies": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/axobject-query": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-3.2.1.tgz",
@@ -8666,6 +8691,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/hamt_plus": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/hamt_plus/-/hamt_plus-1.0.2.tgz",
+      "integrity": "sha512-t2JXKaehnMb9paaYA7J0BX8QQAY8lwfQ9Gjf4pg/mk4krt+cmwmU652HOoWonf+7+EQV97ARPMhhVgU1ra2GhA=="
     },
     "node_modules/handle-thing": {
       "version": "2.0.1",
@@ -14262,6 +14292,11 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+    },
     "node_modules/psl": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
@@ -14690,6 +14725,25 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/recoil": {
+      "version": "0.7.7",
+      "resolved": "https://registry.npmjs.org/recoil/-/recoil-0.7.7.tgz",
+      "integrity": "sha512-8Og5KPQW9LwC577Vc7Ug2P0vQshkv1y3zG3tSSkWMqkWSwHmE+by06L8JtnGocjW6gcCvfwB3YtrJG6/tWivNQ==",
+      "dependencies": {
+        "hamt_plus": "1.0.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.13.1"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
       }
     },
     "node_modules/recursive-readdir": {

--- a/react-app/package.json
+++ b/react-app/package.json
@@ -10,10 +10,12 @@
     "@types/node": "^16.18.68",
     "@types/react": "^18.2.45",
     "@types/react-dom": "^18.2.18",
+    "axios": "^1.6.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.21.0",
     "react-scripts": "5.0.1",
+    "recoil": "^0.7.7",
     "styled-components": "^6.1.1",
     "typescript": "^4.9.5",
     "web-vitals": "^2.1.4"

--- a/react-app/src/App.tsx
+++ b/react-app/src/App.tsx
@@ -7,6 +7,7 @@ import ApiIntroducePage from "./pages/ApiIntroducePage";
 import ApiManagePage from "./pages/ApiManagePage";
 import ApiCreatePage from "./pages/ApiCreatePage";
 import LoginPage from "./pages/LoginPage";
+import LoginProcessPage from "./pages/LoginProcessPage";
 
 function App() {
   return (
@@ -18,7 +19,8 @@ function App() {
         <Route path="/api" element={<ApiIntroducePage/>}/>
         <Route path="/api/manage" element={<ApiManagePage/>}/>
         <Route path="/api/create" element={<ApiCreatePage/>}/>
-        <Route path="/login" element={<LoginPage/>}/>
+        <Route path="/login/:error" element={<LoginPage/>}/>
+        <Route path="/login/oauth2/code/kakao" element={<LoginProcessPage/>}/>
       </Routes>
     </div>
   );

--- a/react-app/src/components/header/profile/HeaderProfile.tsx
+++ b/react-app/src/components/header/profile/HeaderProfile.tsx
@@ -1,8 +1,14 @@
 import {Profile} from "../../../styles/profile/profile.styled";
-import testProfile from "../../../assets/test-profile.png";
 import * as S from "../../../styles/header/Header.styled";
 import {SmallBtn} from "../../../styles/control/SmallBtn.styled";
 import styled from "styled-components";
+import {useRecoilState} from "recoil";
+import {profileData, tokenData} from "../../../store/RecoilState";
+import {Fragment, useEffect, useState} from "react";
+import useAxios from "../../../hooks/useAxios";
+import Modal from "../../modal/Modal";
+import {customAxios} from "../../../utils/CustomAxios";
+import {useNavigate} from "react-router-dom";
 
 const ProfileHeader = styled.h3`
       font-weight: 600;
@@ -11,13 +17,59 @@ const ProfileHeader = styled.h3`
     `;
 
 const HeaderProfile = () => {
+
+  const navigate = useNavigate();
+
+  const [token, setToken] = useRecoilState(tokenData);
+  const [isShowLogoutModal, setIsShowLogoutModal] = useState(false);
+  const [profile, setProfile] = useRecoilState(profileData);
+  const {res, request} = useAxios();
+
+  const loadProfileHandler = async () => {
+      await request("/member/profile", "get");
+  }
+  const logoutHandler = async () => {
+    await customAxios().delete("/auth/signout",
+        {
+          data: {
+            refreshToken: token?.refreshToken || window.localStorage.getItem("refreshToken")
+          }
+        });
+    setToken(null);
+    window.localStorage.setItem("accessToken", '');
+    window.localStorage.setItem("refreshToken", '');
+    setProfile(null);
+    setIsShowLogoutModal(false);
+    window.location.href = "/";
+  }
+
+  useEffect(() => {
+    if(profile === null) {
+      loadProfileHandler();
+    }
+    if (res != undefined) {
+      setProfile(res?.data);
+    }
+  }, [res]);
+
   return (
       <S.HeaderProfile>
-        <Profile src={testProfile} alt={"profileImage"}/>
-        <div>
-          <ProfileHeader>Adam Smith</ProfileHeader>
-          <SmallBtn>로그아웃</SmallBtn>
-        </div>
+        {profile && <Fragment>
+          <Profile src={profile.profileUrl} alt={"profileImage"}/>
+          <div style={{marginLeft: "10px"}}>
+            <ProfileHeader>{profile.nickname}</ProfileHeader>
+            <SmallBtn onClick={() => setIsShowLogoutModal(true)}>로그아웃</SmallBtn>
+          </div>
+        </Fragment>}
+        {!profile &&
+            <SmallBtn onClick={() => navigate("/login/0")}>로그인</SmallBtn>
+        }
+        {isShowLogoutModal && <Modal
+            mark={"question"}
+            isButton={true}
+            text={"로그아웃 하시겠습니까?"}
+            yesCallback={logoutHandler}
+            title={"로그아웃"} closeHandler={() => setIsShowLogoutModal(false)}/>}
       </S.HeaderProfile>
   )
 }

--- a/react-app/src/components/modal/Modal.tsx
+++ b/react-app/src/components/modal/Modal.tsx
@@ -69,7 +69,7 @@ const Modal: React.FC<ModalProps> = (props) => {
                     <S.ModalButtonWrapper onClick={props.yesCallback}>
                       <S.ModalButton>{props.yesText || "확인"}</S.ModalButton>
                     </S.ModalButtonWrapper>
-                    <Line $c={palette["--color-gray-500"]}/>
+                    <Line $c={palette["--color-gray-500"]} $h={40}/>
                     <S.ModalButtonWrapper onClick={props.noCallback || props.closeHandler}>
                       <S.ModalButton>{props.noText || "취소"}</S.ModalButton>
                     </S.ModalButtonWrapper>

--- a/react-app/src/constants/interfaces.tsx
+++ b/react-app/src/constants/interfaces.tsx
@@ -1,3 +1,20 @@
+export interface TokenDto {
+  accessToken: string,
+  refreshToken: string
+}
+
+export interface Profile {
+  memberId: number
+  nickname: string
+  email: string
+  profileUrl: string
+}
+
+export interface ErrorFormat {
+  code: number
+  message: string
+}
+
 export interface ApiData {
   apiId: number
   profileUrl: string

--- a/react-app/src/hooks/useAxios.tsx
+++ b/react-app/src/hooks/useAxios.tsx
@@ -1,0 +1,87 @@
+import {useRecoilState} from "recoil";
+import {tokenData} from "../store/RecoilState";
+import {useState} from "react";
+import * as A from "../utils/CustomAxios";
+import axios, {AxiosError, AxiosResponse} from "axios";
+import {ErrorFormat, TokenDto} from "../constants/interfaces";
+
+const useAxios = () =>  {
+  const [token, setToken] = useRecoilState(tokenData);
+  const [res, setRes] = useState<AxiosResponse>();
+  const [errorMessage, setErrorMessage] = useState<ErrorFormat>();
+  const [isError, setIsError] = useState(false);
+
+  const innerRequest = async (url: string, method: string, body?: any, accessToken?: string, isDouble?: boolean) => {
+    try {
+      switch (method) {
+        case "get":
+          setRes((await A.customAxios(accessToken).get(url)));
+          return;
+        case "post":
+          setRes((await A.customAxios(accessToken).post(url, body)));
+          return;
+        case "put":
+          setRes((await A.customAxios(accessToken).put(url, body)));
+          return;
+        case "patch":
+          setRes((await A.customAxios(accessToken).patch(url, body)));
+          return;
+        case "delete":
+          setRes((await A.customAxios(accessToken).delete(url, body)));
+          return;
+      }
+    } catch (e) {
+      const axiosError = e as AxiosError<ErrorFormat>;
+
+      if (isDouble) { //토큰 재발급 후에도 오류가 나면, 리턴 처리.
+        return axiosError.response?.data;
+      }
+
+      if (axiosError.response?.status === axios.HttpStatusCode.Unauthorized) {
+        A.customAxios(accessToken).post("/auth", {refreshToken: localStorage.getItem("refreshToken")})
+        .then((tokenRes) => {
+          const tokenData: TokenDto = tokenRes.data;
+          localStorage.setItem("accessToken", tokenData.accessToken);
+
+          //재요청
+          innerRequest(url, method, body, tokenData.accessToken, true);
+
+        }).catch(() => { //로그인 필요
+          localStorage.setItem("accessToken", '');
+          localStorage.setItem("refreshToken", '');
+          setToken(null);
+          setIsError(true);
+          return;
+        });
+      } else {
+        setIsError(true);
+        setErrorMessage(axiosError.response?.data);
+        return;
+      }
+    }
+  }
+
+  const request = async (url: string, method: string, body?: any) => {
+    let accessToken = token?.accessToken || window.localStorage.getItem("accessToken");
+    let refreshToken = token?.refreshToken || window.localStorage.getItem("refreshToken");
+
+    accessToken = accessToken || '';
+    refreshToken = refreshToken || '';
+
+    if (token == null && accessToken != null && refreshToken != null) {
+      setToken(
+          {
+            accessToken: accessToken,
+            refreshToken: refreshToken
+          }
+      );
+    }
+    await innerRequest(url, method, body, accessToken);
+  }
+
+  return {
+    res, errorMessage, isError, request
+  };
+}
+
+export default useAxios;

--- a/react-app/src/index.tsx
+++ b/react-app/src/index.tsx
@@ -3,12 +3,15 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 import App from './App';
 import {BrowserRouter} from "react-router-dom";
+import {RecoilRoot} from "recoil";
 
 const root = ReactDOM.createRoot(
   document.getElementById('root') as HTMLElement
 );
 root.render(
     <BrowserRouter>
-      <App />
+      <RecoilRoot>
+        <App />
+      </RecoilRoot>
     </BrowserRouter>
 );

--- a/react-app/src/pages/LoginPage.tsx
+++ b/react-app/src/pages/LoginPage.tsx
@@ -1,23 +1,40 @@
-import {Fragment} from "react";
+import {Fragment, useEffect, useState} from "react";
 import mainLogoLarge from "../assets/main-logo-large.png";
 import kakaoLoginImg from "../assets/kakao_login_large_wide.png";
 import * as S from "../styles/login/Login.styled";
-import {useNavigate} from "react-router-dom";
+import {useNavigate, useParams} from "react-router-dom";
+import Modal from "../components/modal/Modal";
 
 const LoginPage = () => {
+  const param = useParams().error;
+  const [isShowErrorModal, setIsShowErrorModal] = useState(false);
+
+  useEffect(() => {
+    if (param === '1') {
+      setIsShowErrorModal(true);
+    }
+  }, []);
+
   const navigate = useNavigate();
   return (
       <Fragment>
         <S.PageWrapper>
           <S.MainLogo onClick={() => navigate("/")}  src={mainLogoLarge} />
           <S.LoginWrapper>
-            <S.LoginButton src={kakaoLoginImg} />
+            <S.LoginButton onClick={() => window.location.href = "http://localhost:8080/oauth2/authorization/kakao"} src={kakaoLoginImg} />
           </S.LoginWrapper>
           <S.CustomParagraph>해당 서비스는 오직 카카오 로그인 만을 지원합니다.</S.CustomParagraph>
           <S.CustomParagraph>This service only supports Kakao login.</S.CustomParagraph>
           <S.CustomParagraph>수집 하는 항목은 다음과 같습니다.</S.CustomParagraph>
           <S.CustomParagraph>닉네임, 이메일 (사용자 구별 용도)</S.CustomParagraph>
         </S.PageWrapper>
+        {isShowErrorModal && < Modal title={"오류"}
+               text={"로그인에 실패하였습니다!"}
+               mark={"error"}
+               isButton={true}
+               yesCallback={() => setIsShowErrorModal(false)}
+               closeHandler={() => setIsShowErrorModal(false)}
+        />}
       </Fragment>
   )
 }

--- a/react-app/src/pages/LoginProcessPage.tsx
+++ b/react-app/src/pages/LoginProcessPage.tsx
@@ -1,0 +1,41 @@
+import {useNavigate} from "react-router-dom";
+import {customAxios} from "../utils/CustomAxios";
+import {TokenDto} from "../constants/interfaces";
+import {Fragment, useEffect, useState} from "react";
+import {useRecoilState} from "recoil";
+import {tokenData} from "../store/RecoilState";
+
+const LoginProcessPage = () => {
+
+  const [token, setToken] = useRecoilState(tokenData);
+  const navigate = useNavigate();
+
+  const getTokenData = async () => {
+    try {
+      const res = await customAxios().get(window.location.pathname + window.location.search);
+      return res.data;
+    } catch (e) {
+      throw e;
+    }
+  }
+
+  useEffect(() => {
+    getTokenData().then((res) => {
+      localStorage.setItem("accessToken", res.accessToken);
+      localStorage.setItem("refreshToken", res.refreshToken);
+      setToken({
+        accessToken: res.accessToken,
+        refreshToken: res.refreshToken
+      });
+      navigate("/");
+    }).catch(() => {
+      navigate("/login/1");
+    });
+  }, []);
+
+  return (
+      <Fragment/>
+  )
+}
+
+export default LoginProcessPage;

--- a/react-app/src/pages/MyPage.tsx
+++ b/react-app/src/pages/MyPage.tsx
@@ -12,8 +12,11 @@ import PaymentModal from "../components/modal/PaymentModal";
 import IvReModal from "../components/modal/IvReModal";
 import {palette} from "../constants/Styles";
 import {Line} from "../styles/line/line.styled";
+import {useRecoilState} from "recoil";
+import {profileData} from "../store/RecoilState";
 
 const MyPage = () => {
+  const [profile, _] = useRecoilState(profileData);
   const [isShowNicknameModal, setIsShowNicknameModal] = useState(false);
   const [isShowPaymentModal, setIsShowPaymentModal] = useState(false);
   // IvRe == Invite & Request(초대/신쳥)
@@ -44,16 +47,16 @@ const MyPage = () => {
           <S.GradeMargin>
             <img src={testGradeImg} alt={"gradeImg"} width={"30px"} height={"70px"}/>
           </S.GradeMargin>
-          <Profile src={testProfileImg} $size={120}/>
+          <Profile src={profile?.profileUrl} $size={120}/>
           <S.NicknameTextWrapper>
-            <S.NicknameText><strong>Adam Smith</strong> 님</S.NicknameText>
+            <S.NicknameText><strong>{profile?.nickname}</strong> 님</S.NicknameText>
             <S.NicknameText>안녕하세요?</S.NicknameText>
           </S.NicknameTextWrapper>
           <S2.CardWrapper $w={450} $m={20}>
             <S2.Card $h={50} $p={10} $r={10}>
               <S.EmailText>Email</S.EmailText>
               <Line $h={30} $c={palette["--color-gray-500"]}/>
-              <S.EmailText style={{width: "300px"}}>AdamSmith@test.com</S.EmailText>
+              <S.EmailText style={{width: "300px"}}>{profile?.email}</S.EmailText>
             </S2.Card>
           </S2.CardWrapper>
         </S.ProfileWrapper>

--- a/react-app/src/store/RecoilState.tsx
+++ b/react-app/src/store/RecoilState.tsx
@@ -1,0 +1,14 @@
+import {atom} from "recoil";
+import {Profile, TokenDto} from "../constants/interfaces";
+
+//Profile Data
+export const profileData = atom<Profile | null>({
+  key: "profileData",
+  default: null
+});
+
+//Token Data
+export const tokenData = atom<TokenDto | null>({
+  key: "tokenData",
+  default: null
+});

--- a/react-app/src/utils/CustomAxios.ts
+++ b/react-app/src/utils/CustomAxios.ts
@@ -1,0 +1,19 @@
+import axios, {AxiosError, AxiosInstance, AxiosResponse} from "axios";
+import {TokenDto} from "../constants/interfaces";
+import {useRecoilState} from "recoil";
+import {tokenData} from "../store/RecoilState";
+
+const BASE_URL = "http://localhost:8080";
+
+//서버와 토큰을 지정함.
+export const customAxios: (accessToken?: string) => AxiosInstance = (accessToken?: string) => {
+  return axios.create(
+      {
+        baseURL: BASE_URL,
+        headers: {
+          "Authorization": 'Bearer ' + accessToken || localStorage.getItem("accessToken")
+        },
+        withCredentials: true
+      }
+  );
+}


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
- JWT Token Header가 AccessToken.
- JWT 파싱 오류 방치.

**TO-BE**
- Front와의 통신을 위한 CORS 설정.
- JWT Token Header 부분을 Authorization으로 변경.
- JWT 파싱 오류시, 401 에러를 응답으로 줌.
- Profile을 조회할 수 있는 API 구현.
- Recoil을 사용하여, 전역 변수 지정.
- Axios를 사용하여, 서버와 통신 수행.
- Front단에서, withCredentials 옵션을 true로 선언하여, axios로 ajax통신을 수행할 때, 쿠키도 같이 전송할 수 있도록 설정.
- localStorage를 보조적으로 사용하여, 탭이 닫혀도 로그인 상태를 유지할 수 있도록 수행.
- localStorage는 window의 변화에 의해 값이 반영되므로, 동기처리이지만, 윈도우의 변화가 없으면 비동기 처리 같이 보이기도 하기 때문에, Token의 주 관리는 Recoil로 전역 변수를 만들어서 사용하기로 함.

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [ ] API 테스트 